### PR TITLE
Restructure the HTTP handlers

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -70,7 +70,7 @@ func (self *JSONTime) UnmarshalJSON(b []byte) (err error) {
 
 // AdminRebuildDBHandler allows an administrator to rebuild the database from
 // the application directory after hitting a single API end point.
-func AdminRebuildDBHandler(w http.ResponseWriter, r *http.Request) {
+func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (int, error) {
 	//w.WriteHeader(418)
 	//fmt.Fprintf(w, "I'm a teapot!")
 	/*
@@ -103,8 +103,7 @@ func AdminRebuildDBHandler(w http.ResponseWriter, r *http.Request) {
 		`
 	_, err = db.Exec(sqlStmt)
 	if err != nil {
-		log.Printf("%q: %s\n", err, sqlStmt)
-		return
+		return 500, fmt.Errorf("%q: %s", err, sqlStmt)
 	}
 
 	tx, err := db.Begin()
@@ -129,6 +128,7 @@ func AdminRebuildDBHandler(w http.ResponseWriter, r *http.Request) {
 	tx.Commit()
 
 	log.Print("AppStore Database rebuilt successfully.")
+	return 200, nil
 
 }
 

--- a/admin.go
+++ b/admin.go
@@ -128,7 +128,8 @@ func AdminRebuildDBHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	tx.Commit()
 
-	/**/
+	log.Print("AppStore Database rebuilt successfully.")
+
 }
 
 // AdminVersionHandler returns the latest build information from the host

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/gorilla/handlers"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/pborman/getopt"
 	//rsapi "github.com/pebble-dev/rebblestore-api"
 )

--- a/main.go
+++ b/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"database/sql"
 	"fmt"
 	"net/http"
 	"os"
 
 	"github.com/gorilla/handlers"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/pborman/getopt"
 	//rsapi "github.com/pebble-dev/rebblestore-api"
 )
@@ -20,7 +20,16 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Version %s\nBuild Host: %s\nBuild Date: %s\nBuild Hash: %s\n", Buildversionstring, Buildhost, Buildstamp, Buildgithash)
 		return
 	}
-	r := Handlers()
+
+	db, err := sql.Open("sqlite3", "./foo.db")
+	if err != nil {
+		panic("Could not connect to database" + err.Error())
+	}
+
+	// construct the context that will be injected in to handlers
+	context := &handlerContext{db}
+
+	r := Handlers(context)
 	loggedRouter := handlers.LoggingHandler(os.Stdout, r)
 	http.Handle("/", r)
 	http.ListenAndServe(":8080", loggedRouter)

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"os"
 	"testing"
 
@@ -14,7 +15,14 @@ var server *test.Server
 func TestMain(m *testing.M) {
 	var err error
 
-	var r = Handlers()
+	db, err := sql.Open("sqlite3", "./foo_test.db")
+	if err != nil {
+		panic("Could not connect to database" + err.Error())
+	}
+
+	context := &handlerContext{db}
+
+	var r = Handlers(context)
 	r.KeepContext = true
 	loggedRouter := handlers.LoggingHandler(os.Stdout, r)
 	test.RegisterURLVarExtractor(mux.Vars)

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/adams-sarah/test2doc/test"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 var server *test.Server

--- a/routehandler.go
+++ b/routehandler.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"database/sql"
+	"log"
+	"net/http"
+)
+
+// handlerContext is our struct for storing the data we want to inject in to each handler
+// we can also add things like authorization level, user information, templates, etc.
+type handlerContext struct {
+	db *sql.DB
+}
+
+// routeHandler is a struct that implements http.Handler, allowing us to inject a custom context
+// and handle things like authorization and errors in a single place
+// the handler should always return 2 variables, an integer, corrosponding to an HTTP status code
+// and an error object containing whatever error happened (or nil, if no error)
+type routeHandler struct {
+	context *handlerContext
+	H       func(*handlerContext, http.ResponseWriter, *http.Request) (int, error)
+}
+
+func (rh routeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// we can process user verification/auth token parsing and authorization here
+
+	// call the handler function
+	status, err := rh.H(rh.context, w, r)
+
+	// if the handler function returns an error, we log the error and send the appropriate error message
+	if err != nil {
+		log.Printf("HTTP %d: %q", status, err)
+		switch status {
+		case http.StatusNotFound:
+			http.NotFound(w, r)
+		case http.StatusInternalServerError:
+			http.Error(w, http.StatusText(status), status)
+		default:
+			http.Error(w, http.StatusText(status), status)
+		}
+	}
+}

--- a/routes.go
+++ b/routes.go
@@ -16,11 +16,11 @@ func DummyHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // Handlers returns a mux.Router with all possible routes already setup.
-func Handlers() *mux.Router {
+func Handlers(context *handlerContext) *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/", HomeHandler).Methods("GET")
 	r.HandleFunc("/dev/apps", AppsHandler).Methods("GET")
-	r.HandleFunc("/admin/rebuild/db", AdminRebuildDBHandler).Host("localhost")
+	r.Handle("/admin/rebuild/db", routeHandler{context, AdminRebuildDBHandler}).Host("localhost")
 	r.HandleFunc("/admin/version", AdminVersionHandler)
 	r.HandleFunc("/boot/{path:.*}", BootHandler).Methods("GET")
 


### PR DESCRIPTION
Inspired by [this article](https://elithrar.github.io/article/custom-handlers-avoiding-globals/).

I've added a context struct and a custom handler struct. The context only contains the DB now, but can also house user info, authentication, etc. The custom handler (via implementing the ServeHTTP function) allows us to check authentication and handle errors all in a single place.

Please let me know if you have any questions or if there's anything I need to change.