### PR TITLE
Add the getApp() API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 main.apib
 /build/
 /PebbleAppStore
-foo.db
+RebbleAppStore.db
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ environment variable and is typically set to $HOME/go/ on \*nix). This can be
 done by running (for example) the following set of commands:
 
 		GOPATH=go/
-    mkdir -p $GOPATH/src/pebble-dev
+		mkdir -p $GOPATH/src/pebble-dev
 		git clone https://github.com/pebble-dev/rebblestore-api.git $GOPATH/src/pebble-dev/rebblestore-api
 
 Please [go fmt your code](https://blog.golang.org/go-fmt-your-code) and run `go
@@ -28,6 +28,6 @@ should be able to do this automatically before save.
 	 go executable.
 
 ### Database
-1. If you haven't already, download a copy of the Pebble App Store (either as a possibly outdated [torrent](https://www.reddit.com/r/pebble/comments/5g0gmx/in_light_of_recent_news_i_archived_the_app_store/), or by crawling it yourself).
-2. Either create a link, or move your PebbleAppStore folder to `$GOPATH/src/pebble-dev/rebblestore-api/PebbleAppStore`, such that the folder `$GOPATH/src/pebble-dev/rebblestore-api/apps` exists.
+1. If you haven't already, download a copy of the Pebble App Store by using [this tool](https://github.com/azertyfun/PebbleAppStoreCrawler) (you can find a direct download on this page).
+2. Either create a link, or move your PebbleAppStore folder to `$GOPATH/src/pebble-dev/rebblestore-api/PebbleAppStore`, such that the folder `$GOPATH/src/pebble-dev/rebblestore-api/apps` exists; for example: `ln -s ~/Documents/PebbleAppStore $GOPATH/src/pebble-dev/rebblestore-api/PebbleAppStore`.
 3. Start `./rebblestore-api` and access http://localhost:8080/admin/rebuild/db to rebuild the database.

--- a/admin.go
+++ b/admin.go
@@ -101,6 +101,8 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 				author_id integer,
 				tag_ids blob,
 				description text,
+				thumbs_up integer,
+				type text,
 				published_date integer,
 				pbw_url text,
 				rebble_ready integer,
@@ -111,7 +113,8 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 				source_url text,
 				screenshot_urls blob,
 				banner_url text,
-				icon_url text
+				icon_url text,
+				doomsday_backup integer
 			);
 			delete from apps;
 		`
@@ -152,7 +155,7 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 		log.Fatal(err)
 	}
 
-	stmt, err := tx.Prepare("INSERT INTO apps(id, name, author_id, tag_ids, description, published_date, pbw_url, rebble_ready, updated, version, support_url, author_url, source_url, screenshot_urls, banner_url, icon_url) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+	stmt, err := tx.Prepare("INSERT INTO apps(id, name, author_id, tag_ids, description, thumbs_up, type, published_date, pbw_url, rebble_ready, updated, version, support_url, author_url, source_url, screenshot_urls, banner_url, icon_url, doomsday_backup) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -178,7 +181,7 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 			log.Fatal("Could not marshal app screenshots:", err)
 		}
 
-		_, err = stmt.Exec(app.Id, app.Name, app.Author.Id, tag_ids, app.Description, app.Published.UnixNano(), app.AppInfo.PbwUrl, app.AppInfo.RebbleReady, app.AppInfo.Updated.UnixNano(), app.AppInfo.Version, app.AppInfo.SupportUrl, app.AppInfo.AuthorUrl, app.AppInfo.SourceUrl, screenshot_urls, app.Assets.Banner, app.Assets.Icon)
+		_, err = stmt.Exec(app.Id, app.Name, app.Author.Id, tag_ids, app.Description, app.ThumbsUp, app.Type, app.Published.UnixNano(), app.AppInfo.PbwUrl, app.AppInfo.RebbleReady, app.AppInfo.Updated.UnixNano(), app.AppInfo.Version, app.AppInfo.SupportUrl, app.AppInfo.AuthorUrl, app.AppInfo.SourceUrl, screenshot_urls, app.Assets.Banner, app.Assets.Icon, app.DoomsdayBackup)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/admin.go
+++ b/admin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -92,18 +93,25 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 		log.Fatal(err)
 	}
 
+	// tag_ids and screenshot_urls are Marshaled arrays, hence the BLOB type.
 	sqlStmt := `
 			create table apps (
 				id text not null primary key,
 				name text,
 				author_id integer,
-				category text,
+				tag_ids blob,
 				description text,
 				published_date integer,
 				pbw_url text,
 				rebble_ready integer,
 				updated integer,
-				version text
+				version text,
+				support_url text,
+				author_url text,
+				source_url text,
+				screenshot_urls blob,
+				banner_url text,
+				icon_url text
 			);
 			delete from apps;
 		`
@@ -125,24 +133,52 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 		return 500, fmt.Errorf("%q: %s", err, sqlStmt)
 	}
 
+	// Placeholder until we implement an actual collections system.
+	sqlStmt = `
+			create table categories (
+				id text not null primary key,
+				name text,
+				color text
+			);
+			delete from categories;
+		`
+	_, err = db.Exec(sqlStmt)
+	if err != nil {
+		return 500, fmt.Errorf("%q: %s", err, sqlStmt)
+	}
+
 	tx, err := db.Begin()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	stmt, err := tx.Prepare("INSERT INTO apps(id, name, author_id, category, description, published_date, pbw_url, rebble_ready, updated, version) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+	stmt, err := tx.Prepare("INSERT INTO apps(id, name, author_id, tag_ids, description, published_date, pbw_url, rebble_ready, updated, version, support_url, author_url, source_url, screenshot_urls, banner_url, icon_url) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer stmt.Close()
 
 	authors := make(map[string]int)
-	lastId := 0
+	categoriesNames := make(map[string]string)
+	categoriesColors := make(map[string]string)
+	lastAuthorId := 0
 	path, errc := walkFiles("PebbleAppStore/apps")
 	for item := range path {
 		//fmt.Fprintf(w, "File: %s<br />", item)
-		app := parseApp(item, &authors, &lastId)
-		_, err = stmt.Exec(app.Id, app.Name, app.Author.Id, app.Category, app.Description, app.Published.UnixNano(), app.AppInfo.PbwUrl, app.AppInfo.RebbleReady, app.AppInfo.Updated.UnixNano(), app.AppInfo.Version)
+		app := parseApp(item, &authors, &lastAuthorId, &categoriesNames, &categoriesColors)
+
+		tag_ids_s := make([]string, 1)
+		tag_ids_s[0] = app.AppInfo.Tags[0].Id
+		tag_ids, err := json.Marshal(tag_ids_s)
+		if err != nil {
+			log.Fatal("Could not marshal app tags:", err)
+		}
+		screenshot_urls, err := json.Marshal(app.Assets.Screenshots)
+		if err != nil {
+			log.Fatal("Could not marshal app screenshots:", err)
+		}
+
+		_, err = stmt.Exec(app.Id, app.Name, app.Author.Id, tag_ids, app.Description, app.Published.UnixNano(), app.AppInfo.PbwUrl, app.AppInfo.RebbleReady, app.AppInfo.Updated.UnixNano(), app.AppInfo.Version, app.AppInfo.SupportUrl, app.AppInfo.AuthorUrl, app.AppInfo.SourceUrl, screenshot_urls, app.Assets.Banner, app.Assets.Icon)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -153,6 +189,13 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 
 	for author, id := range authors {
 		_, err = tx.Exec("INSERT INTO authors(id, name) VALUES(?, ?)", id, author)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	for id, category := range categoriesNames {
+		_, err = tx.Exec("INSERT INTO categories(id, name, color) VALUES(?, ?, ?)", id, category, categoriesColors[id])
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/application.go
+++ b/application.go
@@ -23,17 +23,21 @@ type RebbleApplication struct {
 	Id          string        `json:"id"`
 	Name        string        `json:"title"`
 	Author      RebbleAuthor  `json:"author"`
-	Category    string        `json:"category_name"`
 	Description string        `json:"description"`
 	Published   JSONTime      `json:"published_date"`
 	AppInfo     RebbleAppInfo `json:"appInfo"`
+	Assets      RebbleAssets  `json:"assets"`
 }
 
 type RebbleAppInfo struct {
-	PbwUrl      string   `json:"pbwUrl"`
-	RebbleReady bool     `json:"rebbleReady"`
-	Updated     JSONTime `json:"updated"`
-	Version     string   `json:"version"`
+	PbwUrl      string           `json:"pbwUrl"`
+	RebbleReady bool             `json:"rebbleReady"`
+	Tags        []RebbleCategory `json:"tags"`
+	Updated     JSONTime         `json:"updated"`
+	Version     string           `json:"version"`
+	SupportUrl  string           `json:"supportUrl"`
+	AuthorUrl   string           `json:"authorUrl"`
+	SourceUrl   string           `json:"sourceUrl"`
 }
 
 type RebbleAuthor struct {
@@ -41,15 +45,33 @@ type RebbleAuthor struct {
 	Name string `json:"name"`
 }
 
+type RebbleAssets struct {
+	Banner      string   `json:"appBanner"`
+	Icon        string   `json:"appIcon"`
+	Screenshots []string `json:"screenshots"`
+}
+
+type RebbleCategory struct {
+	Id    string `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
 // PebbleApplication is used by the parseApp() function. It matches directly the `{id}.json` format.
 type PebbleApplication struct {
-	Id          string                   `json:"id"`
-	Name        string                   `json:"title"`
-	Author      string                   `json:"author"`
-	Category    string                   `json:"category_name"`
-	Description string                   `json:"description"`
-	Published   JSONTime                 `json:"published_date"`
-	Release     PebbleApplicationRelease `json:"latest_release"`
+	Id            string                   `json:"id"`
+	Name          string                   `json:"title"`
+	Author        string                   `json:"author"`
+	CategoryId    string                   `json:"category_id"`
+	CategoryName  string                   `json:"category_name"`
+	CategoryColor string                   `json:"category_color"`
+	Description   string                   `json:"description"`
+	Published     JSONTime                 `json:"published_date"`
+	Release       PebbleApplicationRelease `json:"latest_release"`
+	Website       string                   `json:"website"`
+	Source        string                   `json:"source"`
+	Screenshots   PebbleScreenshotImages   `json:"screenshot_images"`
+	HeaderImages  PebbleHeaderImages       `json:"header_images"`
 }
 
 type PebbleApplicationRelease struct {
@@ -59,7 +81,39 @@ type PebbleApplicationRelease struct {
 	Version   string   `json:"version"`
 }
 
-func parseApp(path string, authors *map[string]int, lastId *int) *RebbleApplication {
+/*
+ * Screenshots and Header images are stored as arrays in the json files. But when there is no screenshot or header, the array is just an empty string, which is fine with dynamically typed languages. However, with Go, we have to redefine UnmarshalJSON for those types.
+ */
+type PebbleHeaderImages []PebbleHeaderImage
+type PebbleScreenshotImages []PebbleScreenshotImage
+
+type PebbleHeaderImage struct {
+	Orig string `json:"orig"`
+}
+
+type PebbleScreenshotImage struct {
+	Screenshot string `json:"144x168"`
+}
+
+func (phi *PebbleHeaderImages) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 || b[0] == '"' {
+		*phi = make([]PebbleHeaderImage, 0)
+		return nil
+	}
+
+	return json.Unmarshal(b, (*([]PebbleHeaderImage))(phi))
+}
+
+func (psi *PebbleScreenshotImages) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 || b[0] == '"' {
+		*psi = make([]PebbleScreenshotImage, 0)
+		return nil
+	}
+
+	return json.Unmarshal(b, (*([]PebbleScreenshotImage))(psi))
+}
+
+func parseApp(path string, authors *map[string]int, lastAuthorId *int, categoriesNames, categoriesColors *map[string]string) *RebbleApplication {
 	f, err := ioutil.ReadFile(path)
 	if err != nil {
 		log.Fatal(err)
@@ -78,14 +132,24 @@ func parseApp(path string, authors *map[string]int, lastId *int) *RebbleApplicat
 
 	// Create author if it doesn't exist
 	if _, ok := (*authors)[data.Apps[0].Author]; !ok {
-		(*authors)[data.Apps[0].Author] = *lastId + 1
-		*lastId = *lastId + 1
+		(*authors)[data.Apps[0].Author] = *lastAuthorId + 1
+		*lastAuthorId = *lastAuthorId + 1
+	}
+
+	// Create category if it doesn't exist
+	if _, ok := (*categoriesNames)[data.Apps[0].CategoryId]; !ok {
+		(*categoriesNames)[data.Apps[0].CategoryId] = data.Apps[0].CategoryName
+		(*categoriesColors)[data.Apps[0].CategoryId] = data.Apps[0].CategoryColor
 	}
 
 	app := RebbleApplication{}
+	app.AppInfo.Tags = make([]RebbleCategory, 1)
+	app.Assets.Screenshots = make([]string, 0)
 	app.Id = data.Apps[0].Id
 	app.Name = data.Apps[0].Name
-	app.Category = data.Apps[0].Category
+	app.AppInfo.Tags[0].Id = data.Apps[0].CategoryId
+	app.AppInfo.Tags[0].Name = data.Apps[0].CategoryName
+	app.AppInfo.Tags[0].Color = data.Apps[0].CategoryColor
 	app.Published = data.Apps[0].Published
 	app.Description = data.Apps[0].Description
 	app.Author = RebbleAuthor{(*authors)[data.Apps[0].Author], data.Apps[0].Author}
@@ -93,6 +157,18 @@ func parseApp(path string, authors *map[string]int, lastId *int) *RebbleApplicat
 	app.AppInfo.RebbleReady = false
 	app.AppInfo.Updated = data.Apps[0].Release.Published
 	app.AppInfo.Version = data.Apps[0].Release.Version
+	app.AppInfo.SupportUrl = ""
+	app.AppInfo.AuthorUrl = data.Apps[0].Website
+	app.AppInfo.SourceUrl = data.Apps[0].Source
+	if len(data.Apps[0].HeaderImages) > 0 {
+		app.Assets.Banner = data.Apps[0].HeaderImages[0].Orig
+	} else {
+		app.Assets.Banner = ""
+	}
+	app.Assets.Icon = ""
+	for _, screenshot := range data.Apps[0].Screenshots {
+		app.Assets.Screenshots = append(app.Assets.Screenshots, screenshot.Screenshot)
+	}
 
 	return &app
 }
@@ -168,19 +244,50 @@ func AppHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer db.Close()
-	rows, err := db.Query("SELECT apps.id, apps.name, apps.author_id, authors.name, apps.category, apps.description, apps.published_date, apps.pbw_url, apps.rebble_ready, apps.updated, apps.version FROM apps JOIN authors ON apps.author_id = authors.id WHERE apps.id=?", mux.Vars(r)["id"])
+	rows, err := db.Query("SELECT apps.id, apps.name, apps.author_id, authors.name, apps.tag_ids, apps.description, apps.published_date, apps.pbw_url, apps.rebble_ready, apps.updated, apps.version, apps.support_url, apps.author_url, apps.source_url, apps.screenshot_urls, apps.banner_url, apps.icon_url FROM apps JOIN authors ON apps.author_id = authors.id WHERE apps.id=?", mux.Vars(r)["id"])
 	if err != nil {
 		log.Fatal(err)
 	}
-	rows.Next()
+	exists := rows.Next()
+	if !exists {
+		w.WriteHeader(404)
+		w.Write([]byte("No application with this ID"))
+		return
+	}
+
 	app := RebbleApplication{}
 	var t_published, t_updated int64
-	err = rows.Scan(&app.Id, &app.Name, &app.Author.Id, &app.Author.Name, &app.Category, &app.Description, &t_published, &app.AppInfo.PbwUrl, &app.AppInfo.RebbleReady, &t_updated, &app.AppInfo.Version)
+	var tagIds_b []byte
+	var tagIds []string
+	var screenshots_b []byte
+	var screenshots []string
+	err = rows.Scan(&app.Id, &app.Name, &app.Author.Id, &app.Author.Name, &tagIds_b, &app.Description, &t_published, &app.AppInfo.PbwUrl, &app.AppInfo.RebbleReady, &t_updated, &app.AppInfo.Version, &app.AppInfo.SupportUrl, &app.AppInfo.AuthorUrl, &app.AppInfo.SourceUrl, &screenshots_b, &app.Assets.Banner, &app.Assets.Icon)
 	if err != nil {
 		log.Fatal(err)
 	}
 	app.Published.Time = time.Unix(0, t_published)
 	app.AppInfo.Updated.Time = time.Unix(0, t_updated)
+	json.Unmarshal(tagIds_b, &tagIds)
+	app.AppInfo.Tags = make([]RebbleCategory, len(tagIds))
+	json.Unmarshal(screenshots_b, &screenshots)
+
+	for i, tagId := range tagIds {
+		rows, err := db.Query("SELECT id, name, color FROM categories WHERE id=?", tagId)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		rows.Next()
+		err = rows.Scan(&app.AppInfo.Tags[i].Id, &app.AppInfo.Tags[i].Name, &app.AppInfo.Tags[i].Color)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	app.Assets.Screenshots = make([]string, len(screenshots))
+	for i, screenshot := range screenshots {
+		app.Assets.Screenshots[i] = screenshot
+	}
 
 	data, err := json.MarshalIndent(app, "", "\t")
 	if err != nil {

--- a/application.go
+++ b/application.go
@@ -45,14 +45,12 @@ func parseApp(path string) *PebbleApplication {
 
 // HomeHandler is the index page.
 func HomeHandler(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/" {
-		w.WriteHeader(404)
-		w.Write([]byte("404 Not Found<br />Try <a href='/'>Home</a>?"))
-		return
+	data, err := ioutil.ReadFile("static/home.html")
+	if err != nil {
+		log.Fatal("Could not read static/home.html")
 	}
-	fmt.Fprintf(w, "<a href='/admin/version'>Version</a><br />")
-	fmt.Fprintf(w, "<a href='/admin/rebuild/db'>Rebuild the database</a><br />")
-	fmt.Fprintf(w, "<a href='/dev/apps'>Apps</a><br />")
+
+	fmt.Fprintf(w, string(data))
 }
 
 func RecurseFolder(w http.ResponseWriter, path string, f os.FileInfo, lvl int) {

--- a/routes.go
+++ b/routes.go
@@ -20,6 +20,7 @@ func Handlers() *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/", HomeHandler).Methods("GET")
 	r.HandleFunc("/dev/apps", AppsHandler).Methods("GET")
+	r.HandleFunc("/dev/apps/id/{id}", AppHandler).Methods("GET")
 	r.HandleFunc("/admin/rebuild/db", AdminRebuildDBHandler).Host("localhost")
 	r.HandleFunc("/admin/version", AdminVersionHandler)
 	//r.HandleFunc("/boot/{path:.*}", BootHandler).Methods("GET")

--- a/static/home.html
+++ b/static/home.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Rebblestore-API Backend</title>
+    </head>
+
+    <body>
+        <p>
+            <a href='/admin/version'>Version</a><br />
+            <a href='/admin/rebuild/db'>Rebuild the database</a><br />
+        </p>
+        
+        <hr />
+        
+        <p>
+            <a href='/dev/apps'>Apps</a><br />
+            <a href='http://localhost:8080/boot/android/v3/4?app_version=4.3'>Android bootstrap</a><br />
+            <a href='http://localhost:8080/boot/ios/v3/1/1?app_version=4.3'>iOS bootstrap</a>
+        </p>
+    </body>
+</html>


### PR DESCRIPTION
This pull request implements getApp(), with the exception of multiple platforms support - I'll have to rewrite the crawler to crawl every pebble app for every platform.

Also commit 8d906e0 makes the home page an html file in static/, making it much easier to modify.