### PR TITLE
Convert handlers to use new format

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -130,7 +130,7 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 		`
 	_, err = db.Exec(sqlStmt)
 	if err != nil {
-		return 500, fmt.Errorf("%q: %s", err, sqlStmt)
+		return http.StatusInternalServerError, fmt.Errorf("%q: %s", err, sqlStmt)
 	}
 
 	// Placeholder until we implement an actual collections system.
@@ -144,7 +144,7 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 		`
 	_, err = db.Exec(sqlStmt)
 	if err != nil {
-		return 500, fmt.Errorf("%q: %s", err, sqlStmt)
+		return http.StatusInternalServerError, fmt.Errorf("%q: %s", err, sqlStmt)
 	}
 
 	tx, err := db.Begin()
@@ -216,7 +216,7 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 	tx.Commit()
 
 	log.Print("AppStore Database rebuilt successfully.")
-	return 200, nil
+	return http.StatusOK, nil
 
 }
 

--- a/admin.go
+++ b/admin.go
@@ -89,18 +89,9 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 
 	db := ctx.db
 
-	// remove the old apps table
-
-	sqlStmt := "drop table apps"
-
-	_, err := db.Exec(sqlStmt)
-
-	if err != nil {
-		log.Fatal("%q: %s\n", err, sqlStmt)
-	}
-
 	// tag_ids and screenshot_urls are Marshaled arrays, hence the BLOB type.
-	sqlStmt = `
+	sqlStmt := `
+			drop table apps;
 			create table apps (
 				id text not null primary key,
 				name text,
@@ -125,13 +116,14 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 			);
 			delete from apps;
 		`
-	_, err = db.Exec(sqlStmt)
+	_, err := db.Exec(sqlStmt)
 	if err != nil {
 		log.Fatal("%q: %s\n", err, sqlStmt)
 	}
 
 	// Placeholder until we implement an actual author/developer system.
 	sqlStmt = `
+			drop table authors;
 			create table authors (
 				id text not null primary key,
 				name text
@@ -145,6 +137,7 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 
 	// Placeholder until we implement an actual collections system.
 	sqlStmt = `
+			drop table categories;
 			create table categories (
 				id text not null primary key,
 				name text,

--- a/admin.go
+++ b/admin.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -87,11 +86,8 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 
 	//return /*
 	//db.Close()
-	os.Remove("./RebbleAppStore.db")
-	db, err := sql.Open("sqlite3", "./RebbleAppStore.db")
-	if err != nil {
-		log.Fatal(err)
-	}
+
+	db := ctx.db
 
 	// tag_ids and screenshot_urls are Marshaled arrays, hence the BLOB type.
 	sqlStmt := `
@@ -119,7 +115,7 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 			);
 			delete from apps;
 		`
-	_, err = db.Exec(sqlStmt)
+	_, err := db.Exec(sqlStmt)
 	if err != nil {
 		log.Fatal("%q: %s\n", err, sqlStmt)
 	}

--- a/admin.go
+++ b/admin.go
@@ -89,8 +89,18 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 
 	db := ctx.db
 
+	// remove the old apps table
+
+	sqlStmt := "drop table apps"
+
+	_, err := db.Exec(sqlStmt)
+
+	if err != nil {
+		log.Fatal("%q: %s\n", err, sqlStmt)
+	}
+
 	// tag_ids and screenshot_urls are Marshaled arrays, hence the BLOB type.
-	sqlStmt := `
+	sqlStmt = `
 			create table apps (
 				id text not null primary key,
 				name text,
@@ -115,7 +125,7 @@ func AdminRebuildDBHandler(ctx *handlerContext, w http.ResponseWriter, r *http.R
 			);
 			delete from apps;
 		`
-	_, err := db.Exec(sqlStmt)
+	_, err = db.Exec(sqlStmt)
 	if err != nil {
 		log.Fatal("%q: %s\n", err, sqlStmt)
 	}

--- a/application.go
+++ b/application.go
@@ -286,7 +286,7 @@ func AppsHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (i
 			ORDER BY published_date ASC LIMIT 20
 	`)
 	if err != nil {
-		return 500, err
+		return http.StatusInternalServerError, err
 	}
 
 	for rows.Next() {
@@ -295,7 +295,7 @@ func AppsHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (i
 		fmt.Fprintf(w, "Item: %s\n Author: %s\n\n", item.Name, item.Author.Name)
 	}
 
-	return 200, nil
+	return http.StatusOK, nil
 }
 
 // AppHandler returns a particular application from the backend DB as JSON
@@ -304,12 +304,12 @@ func AppHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (in
 
 	rows, err := db.Query("SELECT apps.id, apps.name, apps.author_id, authors.name, apps.tag_ids, apps.description, apps.thumbs_up, apps.type, apps.supported_platforms, apps.published_date, apps.pbw_url, apps.rebble_ready, apps.updated, apps.version, apps.support_url, apps.author_url, apps.source_url, apps.screenshot_urls, apps.banner_url, apps.icon_url, apps.doomsday_backup FROM apps JOIN authors ON apps.author_id = authors.id WHERE apps.id=?", mux.Vars(r)["id"])
 	if err != nil {
-		return 500, err
+		return http.StatusInternalServerError, err
 	}
 
 	exists := rows.Next()
 	if !exists {
-		return 404, errors.New("No application with this ID")
+		return http.StatusNotFound, errors.New("No application with this ID")
 	}
 
 	app := RebbleApplication{}
@@ -321,7 +321,7 @@ func AppHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (in
 	var screenshots *([]RebbleScreenshotsPlatform)
 	err = rows.Scan(&app.Id, &app.Name, &app.Author.Id, &app.Author.Name, &tagIds_b, &app.Description, &app.ThumbsUp, &app.Type, &supportedPlatforms_b, &t_published, &app.AppInfo.PbwUrl, &app.AppInfo.RebbleReady, &t_updated, &app.AppInfo.Version, &app.AppInfo.SupportUrl, &app.AppInfo.AuthorUrl, &app.AppInfo.SourceUrl, &screenshots_b, &app.Assets.Banner, &app.Assets.Icon, &app.DoomsdayBackup)
 	if err != nil {
-		return 500, err
+		return http.StatusInternalServerError, err
 	}
 	json.Unmarshal(supportedPlatforms_b, &app.SupportedPlatforms)
 	app.Published.Time = time.Unix(0, t_published)
@@ -334,7 +334,7 @@ func AppHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (in
 	for i, tagId := range tagIds {
 		rows, err := db.Query("SELECT id, name, color FROM categories WHERE id=?", tagId)
 		if err != nil {
-			return 500, err
+			return http.StatusInternalServerError, err
 		}
 
 		rows.Next()
@@ -352,7 +352,7 @@ func AppHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (in
 	// Send the JSON object back to the user
 	w.Header().Add("content-type", "application/json")
 	w.Write(data)
-	return 200, nil
+	return http.StatusOK, nil
 }
 
 func WriteCommonHeaders(w http.ResponseWriter) {

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 		return
 	}
 
-	db, err := sql.Open("sqlite3", "./foo.db")
+	db, err := sql.Open("sqlite3", "./RebbleAppStore.db")
 	if err != nil {
 		panic("Could not connect to database" + err.Error())
 	}

--- a/routes.go
+++ b/routes.go
@@ -19,8 +19,8 @@ func DummyHandler(w http.ResponseWriter, r *http.Request) {
 func Handlers(context *handlerContext) *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/", HomeHandler).Methods("GET")
-	r.HandleFunc("/dev/apps", AppsHandler).Methods("GET")
-	r.HandleFunc("/dev/apps/id/{id}", AppHandler).Methods("GET")
+	r.Handle("/dev/apps", routeHandler{context, AppsHandler}).Methods("GET")
+	r.Handle("/dev/apps/id/{id}", routeHandler{context, AppHandler}).Methods("GET")
 	r.Handle("/admin/rebuild/db", routeHandler{context, AdminRebuildDBHandler}).Host("localhost")
 	r.HandleFunc("/admin/version", AdminVersionHandler)
 	//r.HandleFunc("/boot/{path:.*}", BootHandler).Methods("GET")


### PR DESCRIPTION
AppHandler and AppsHandler now use the new "routehandler" format, they no longer create connections to the DB, but use the DB passed through the context. They also return status codes and error objects rather than logging it themselves (or calling log.Fatal and crashing the server 😁).