### PR TITLE
Move some DB queries to `db` package

### DIFF
--- a/application.go
+++ b/application.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"pebble-dev/rebblestore-api/db"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -18,74 +19,14 @@ type PebbleAppList struct {
 	Apps []*PebbleApplication `json:"data"`
 }
 
-// RebbleApplication contains Pebble App information from the DB
-type RebbleApplication struct {
-	Id                 string        `json:"id"`
-	Name               string        `json:"title"`
-	Author             RebbleAuthor  `json:"author"`
-	Description        string        `json:"description"`
-	ThumbsUp           int           `json:"thumbs_up"`
-	Type               string        `json:"type"`
-	SupportedPlatforms []string      `json:"supported_platforms"`
-	Published          JSONTime      `json:"published_date"`
-	AppInfo            RebbleAppInfo `json:"appInfo"`
-	Assets             RebbleAssets  `json:"assets"`
-	DoomsdayBackup     bool          `json:"doomsday_backup"`
-}
-
 // RebbleTagList contains a list of tag. Used by getApi(id)
 type RebbleTagList struct {
-	Tags []RebbleCollection `json:"tags"`
+	Tags []db.RebbleCollection `json:"tags"`
 }
 
 // RebbleChangelog contains a list of version changes for an app
 type RebbleChangelog struct {
-	Versions []RebbleVersion `json:"versions"`
-}
-
-// RebbleVersion contains information about a specific version of an app
-type RebbleVersion struct {
-	Number      string   `json:"number"`
-	ReleaseDate JSONTime `json:"release_date"`
-	Description string   `json:"description"`
-}
-
-// RebbleAppInfo contains information about the app (pbw url, versioning, links, etc.)
-type RebbleAppInfo struct {
-	PbwUrl      string             `json:"pbwUrl"`
-	RebbleReady bool               `json:"rebbleReady"`
-	Tags        []RebbleCollection `json:"tags"`
-	Updated     JSONTime           `json:"updated"`
-	Version     string             `json:"version"`
-	SupportUrl  string             `json:"supportUrl"`
-	AuthorUrl   string             `json:"authorUrl"`
-	SourceUrl   string             `json:"sourceUrl"`
-}
-
-// RebbleAuthor describes the autor of a Rebble app (ID and name)
-type RebbleAuthor struct {
-	Id   int    `json:"id"`
-	Name string `json:"name"`
-}
-
-// RebbleAssets describes the list of assets of a Rebble app (banner, icon, screenshots)
-type RebbleAssets struct {
-	Banner      string                         `json:"appBanner"`
-	Icon        string                         `json:"appIcon"`
-	Screenshots *([]RebbleScreenshotsPlatform) `json:"screenshots"`
-}
-
-// RebbleScreenshotsPlatform contains a list of screenshots specific to some hardware (since each Pebble watch renders UI differently)
-type RebbleScreenshotsPlatform struct {
-	Platform    string   `json:"platform"`
-	Screenshots []string `json:"screenshots"`
-}
-
-// RebbleCollection describes the collection (category) of a Rebble application
-type RebbleCollection struct {
-	Id    string `json:"id"`
-	Name  string `json:"name"`
-	Color string `json:"color"`
+	Versions []db.RebbleVersion `json:"versions"`
 }
 
 // PebbleApplication is used by the parseApp() function. It matches directly the `{id}.json` format.
@@ -97,7 +38,7 @@ type PebbleApplication struct {
 	CategoryName       string                   `json:"category_name"`
 	CategoryColor      string                   `json:"category_color"`
 	Description        string                   `json:"description"`
-	Published          JSONTime                 `json:"published_date"`
+	Published          db.JSONTime              `json:"published_date"`
 	Release            PebbleApplicationRelease `json:"latest_release"`
 	Website            string                   `json:"website"`
 	Source             string                   `json:"source"`
@@ -113,17 +54,17 @@ type PebbleApplication struct {
 
 // PebbleApplicationRelease describes the `release` tag of a pebble JSON
 type PebbleApplicationRelease struct {
-	Id        string   `json:"id"`
-	PbwUrl    string   `json:"pbw_file"`
-	Published JSONTime `json:"published_date"`
-	Version   string   `json:"version"`
+	Id        string      `json:"id"`
+	PbwUrl    string      `json:"pbw_file"`
+	Published db.JSONTime `json:"published_date"`
+	Version   string      `json:"version"`
 }
 
 // PebbleVersion describes a version change
 type PebbleVersion struct {
-	Version   string   `json:"version"`
-	Published JSONTime `json:"published_date"`
-	Notes     string   `json:"release_notes"`
+	Version   string      `json:"version"`
+	Published db.JSONTime `json:"published_date"`
+	Notes     string      `json:"release_notes"`
 }
 
 // PebbleCompatibility describes the `compatibility` tag of a pebble JSON
@@ -187,7 +128,7 @@ func (pi *PebbleIcons) UnmarshalJSON(b []byte) error {
 	return json.Unmarshal(b, (*(map[string]string))(pi))
 }
 
-func parseApp(path string, authors *map[string]int, lastAuthorId *int, collections *map[string]RebbleCollection) (*RebbleApplication, *[]RebbleVersion, error) {
+func parseApp(path string, authors *map[string]int, lastAuthorId *int, collections *map[string]db.RebbleCollection) (*db.RebbleApplication, *[]db.RebbleVersion, error) {
 	f, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, nil, err
@@ -212,16 +153,16 @@ func parseApp(path string, authors *map[string]int, lastAuthorId *int, collectio
 
 	// Create collection if it doesn't exist
 	if _, ok := (*collections)[data.Apps[0].CategoryId]; !ok {
-		(*collections)[data.Apps[0].CategoryId] = RebbleCollection{
+		(*collections)[data.Apps[0].CategoryId] = db.RebbleCollection{
 			Id:    data.Apps[0].CategoryId,
 			Name:  data.Apps[0].CategoryName,
 			Color: data.Apps[0].CategoryColor,
 		}
 	}
 
-	app := RebbleApplication{}
-	app.AppInfo.Tags = make([]RebbleCollection, 1)
-	screenshots := make(([]RebbleScreenshotsPlatform), 0)
+	app := db.RebbleApplication{}
+	app.AppInfo.Tags = make([]db.RebbleCollection, 1)
+	screenshots := make(([]db.RebbleScreenshotsPlatform), 0)
 	app.Assets.Screenshots = &screenshots
 
 	supportedPlatforms := make([]string, 0)
@@ -254,7 +195,7 @@ func parseApp(path string, authors *map[string]int, lastAuthorId *int, collectio
 	app.ThumbsUp = data.Apps[0].Hearts
 	app.Type = data.Apps[0].Type
 	app.SupportedPlatforms = supportedPlatforms
-	app.Author = RebbleAuthor{(*authors)[data.Apps[0].Author], data.Apps[0].Author}
+	app.Author = db.RebbleAuthor{(*authors)[data.Apps[0].Author], data.Apps[0].Author}
 	app.AppInfo.PbwUrl = data.Apps[0].Release.PbwUrl
 	app.AppInfo.RebbleReady = false
 	app.AppInfo.Updated = data.Apps[0].Release.Published
@@ -270,7 +211,7 @@ func parseApp(path string, authors *map[string]int, lastAuthorId *int, collectio
 	if icon, ok := data.Apps[0].Icons["48x48"]; ok {
 		app.Assets.Icon = icon
 	}
-	screenshots = append(*app.Assets.Screenshots, RebbleScreenshotsPlatform{data.Apps[0].ScreenshotHardware, make([]string, 0)})
+	screenshots = append(*app.Assets.Screenshots, db.RebbleScreenshotsPlatform{data.Apps[0].ScreenshotHardware, make([]string, 0)})
 	app.Assets.Screenshots = &screenshots
 	for _, screenshot := range data.Apps[0].Screenshots {
 		for _, s := range screenshot {
@@ -279,7 +220,7 @@ func parseApp(path string, authors *map[string]int, lastAuthorId *int, collectio
 	}
 	app.DoomsdayBackup = false
 
-	versions := make([]RebbleVersion, len(data.Apps[0].Changelog))
+	versions := make([]db.RebbleVersion, len(data.Apps[0].Changelog))
 	for i, pv := range data.Apps[0].Changelog {
 		versions[i].Number = pv.Version
 		versions[i].Description = pv.Notes
@@ -323,9 +264,9 @@ func RecurseFolder(w http.ResponseWriter, path string, f os.FileInfo, lvl int) {
 
 // AppsHandler lists all of the available applications from the backend DB.
 func AppsHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (int, error) {
-	db := ctx.db
+	dbHandler := ctx.db
 
-	rows, err := db.Query(`
+	rows, err := dbHandler.Query(`
 			SELECT apps.name, authors.name
 			FROM apps
 			JOIN authors ON apps.author_id = authors.id
@@ -336,7 +277,7 @@ func AppsHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (i
 	}
 
 	for rows.Next() {
-		item := RebbleApplication{}
+		item := db.RebbleApplication{}
 		err = rows.Scan(&item.Name, &item.Author.Name)
 		fmt.Fprintf(w, "Item: %s\n Author: %s\n\n", item.Name, item.Author.Name)
 	}
@@ -346,9 +287,9 @@ func AppsHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (i
 
 // AppHandler returns a particular application from the backend DB as JSON
 func AppHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (int, error) {
-	db := ctx.db
+	dbHandler := ctx.db
 
-	rows, err := db.Query("SELECT apps.id, apps.name, apps.author_id, authors.name, apps.tag_ids, apps.description, apps.thumbs_up, apps.type, apps.supported_platforms, apps.published_date, apps.pbw_url, apps.rebble_ready, apps.updated, apps.version, apps.support_url, apps.author_url, apps.source_url, apps.screenshot_urls, apps.banner_url, apps.icon_url, apps.doomsday_backup FROM apps JOIN authors ON apps.author_id = authors.id WHERE apps.id=?", mux.Vars(r)["id"])
+	rows, err := dbHandler.Query("SELECT apps.id, apps.name, apps.author_id, authors.name, apps.tag_ids, apps.description, apps.thumbs_up, apps.type, apps.supported_platforms, apps.published_date, apps.pbw_url, apps.rebble_ready, apps.updated, apps.version, apps.support_url, apps.author_url, apps.source_url, apps.screenshot_urls, apps.banner_url, apps.icon_url, apps.doomsday_backup FROM apps JOIN authors ON apps.author_id = authors.id WHERE apps.id=?", mux.Vars(r)["id"])
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
@@ -358,13 +299,13 @@ func AppHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (in
 		return http.StatusNotFound, errors.New("No application with this ID")
 	}
 
-	app := RebbleApplication{}
+	app := db.RebbleApplication{}
 	var supportedPlatforms_b []byte
 	var t_published, t_updated int64
 	var tagIds_b []byte
 	var tagIds []string
 	var screenshots_b []byte
-	var screenshots *([]RebbleScreenshotsPlatform)
+	var screenshots *([]db.RebbleScreenshotsPlatform)
 	err = rows.Scan(&app.Id, &app.Name, &app.Author.Id, &app.Author.Name, &tagIds_b, &app.Description, &app.ThumbsUp, &app.Type, &supportedPlatforms_b, &t_published, &app.AppInfo.PbwUrl, &app.AppInfo.RebbleReady, &t_updated, &app.AppInfo.Version, &app.AppInfo.SupportUrl, &app.AppInfo.AuthorUrl, &app.AppInfo.SourceUrl, &screenshots_b, &app.Assets.Banner, &app.Assets.Icon, &app.DoomsdayBackup)
 	if err != nil {
 		return http.StatusInternalServerError, err
@@ -373,12 +314,12 @@ func AppHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (in
 	app.Published.Time = time.Unix(0, t_published)
 	app.AppInfo.Updated.Time = time.Unix(0, t_updated)
 	json.Unmarshal(tagIds_b, &tagIds)
-	app.AppInfo.Tags = make([]RebbleCollection, len(tagIds))
+	app.AppInfo.Tags = make([]db.RebbleCollection, len(tagIds))
 	json.Unmarshal(screenshots_b, &screenshots)
 	app.Assets.Screenshots = screenshots
 
 	for i, tagId := range tagIds {
-		rows, err := db.Query("SELECT id, name, color FROM collections WHERE id=?", tagId)
+		rows, err := dbHandler.Query("SELECT id, name, color FROM collections WHERE id=?", tagId)
 		if err != nil {
 			return http.StatusInternalServerError, err
 		}
@@ -403,9 +344,9 @@ func AppHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (in
 
 // TagsHandler returns the list of tags of a particular appliction as JSON
 func TagsHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (int, error) {
-	db := ctx.db
+	dbHandler := ctx.db
 
-	rows, err := db.Query("SELECT apps.tag_ids FROM apps")
+	rows, err := dbHandler.Query("SELECT apps.tag_ids FROM apps")
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
@@ -422,10 +363,10 @@ func TagsHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (i
 	}
 	json.Unmarshal(tagIds_b, &tagIds)
 	tagList := RebbleTagList{}
-	tagList.Tags = make([]RebbleCollection, len(tagIds))
+	tagList.Tags = make([]db.RebbleCollection, len(tagIds))
 
 	for i, tagId := range tagIds {
-		rows, err := db.Query("SELECT id, name, color FROM collections WHERE id=?", tagId)
+		rows, err := dbHandler.Query("SELECT id, name, color FROM collections WHERE id=?", tagId)
 		if err != nil {
 			return http.StatusInternalServerError, err
 		}
@@ -451,9 +392,9 @@ func TagsHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (i
 
 // VersionsHandler returns the server version
 func VersionsHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (int, error) {
-	db := ctx.db
+	dbHandler := ctx.db
 
-	rows, err := db.Query("SELECT apps.versions FROM apps")
+	rows, err := dbHandler.Query("SELECT apps.versions FROM apps")
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
@@ -463,7 +404,7 @@ func VersionsHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request
 	}
 
 	var versions_b []byte
-	var versions []RebbleVersion
+	var versions []db.RebbleVersion
 	err = rows.Scan(&versions_b)
 	if err != nil {
 		return http.StatusInternalServerError, err

--- a/application.go
+++ b/application.go
@@ -260,28 +260,15 @@ func RecurseFolder(w http.ResponseWriter, path string, f os.FileInfo, lvl int) {
 	}
 }
 
-//var db *sql.DB
-
 // AppsHandler lists all of the available applications from the backend DB.
 func AppsHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (int, error) {
-	dbHandler := ctx.db
-
-	rows, err := dbHandler.Query(`
-			SELECT apps.name, authors.name
-			FROM apps
-			JOIN authors ON apps.author_id = authors.id
-			ORDER BY published_date ASC LIMIT 20
-	`)
+	apps, err := db.GetApps(ctx.db)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
-
-	for rows.Next() {
-		item := db.RebbleApplication{}
-		err = rows.Scan(&item.Name, &item.Author.Name)
-		fmt.Fprintf(w, "Item: %s\n Author: %s\n\n", item.Name, item.Author.Name)
+	for _, app := range apps {
+		fmt.Fprintf(w, "Item: %s\n Author: %s\n\n", app.Name, app.Author.Name)
 	}
-
 	return http.StatusOK, nil
 }
 
@@ -318,8 +305,8 @@ func AppHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (in
 	json.Unmarshal(screenshots_b, &screenshots)
 	app.Assets.Screenshots = screenshots
 
-	for i, tagId := range tagIds {
-		rows, err := dbHandler.Query("SELECT id, name, color FROM collections WHERE id=?", tagId)
+	for i, tagID := range tagIds {
+		rows, err := dbHandler.Query("SELECT id, name, color FROM collections WHERE id=?", tagID)
 		if err != nil {
 			return http.StatusInternalServerError, err
 		}

--- a/application.go
+++ b/application.go
@@ -262,7 +262,7 @@ func RecurseFolder(w http.ResponseWriter, path string, f os.FileInfo, lvl int) {
 
 // AppsHandler lists all of the available applications from the backend DB.
 func AppsHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (int, error) {
-	apps, err := db.GetApps(ctx.db)
+	apps, err := ctx.db.GetApps()
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}

--- a/collection.go
+++ b/collection.go
@@ -169,7 +169,7 @@ func CollectionHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	apps, err := db.GetAppsForCollection(ctx.db, mux.Vars(r)["id"])
+	apps, err := ctx.db.GetAppsForCollection(mux.Vars(r)["id"])
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}

--- a/collection.go
+++ b/collection.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"pebble-dev/rebblestore-api/db"
 	"strconv"
 	"time"
 
@@ -128,7 +129,7 @@ func sortApps(apps *([]RebbleApplication), sortByPopular bool) *([]RebbleApplica
 
 // CollectionHandler serves a list of cards from a collection
 func CollectionHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (int, error) {
-	db := ctx.db
+	dbHandler := ctx.db
 
 	urlquery := r.URL.Query()
 
@@ -171,7 +172,7 @@ func CollectionHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	rows, err := db.Query("SELECT apps FROM collections WHERE id=?", mux.Vars(r)["id"])
+	rows, err := dbHandler.Query("SELECT apps FROM collections WHERE id=?", mux.Vars(r)["id"])
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
@@ -188,7 +189,7 @@ func CollectionHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Reque
 
 	apps := make([]RebbleApplication, 0)
 	for _, id := range appIds {
-		rows, err = db.Query("SELECT id, name, type, thumbs_up, icon_url, published_date, supported_platforms FROM apps WHERE id=?", id)
+		rows, err = dbHandler.Query("SELECT id, name, type, thumbs_up, icon_url, published_date, supported_platforms FROM apps WHERE id=?", id)
 		if err != nil {
 			return http.StatusInternalServerError, err
 		}
@@ -210,9 +211,9 @@ func CollectionHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Reque
 		apps = apps[(page-1)*12 : page*12]
 	}
 
-	var cards RebbleCards
+	var cards db.RebbleCards
 	for _, app := range apps {
-		cards.Cards = append(cards.Cards, RebbleCard{
+		cards.Cards = append(cards.Cards, db.RebbleCard{
 			Id:       app.Id,
 			Title:    app.Name,
 			Type:     app.Type,

--- a/collection.go
+++ b/collection.go
@@ -172,20 +172,10 @@ func CollectionHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	rows, err := dbHandler.Query("SELECT apps FROM collections WHERE id=?", mux.Vars(r)["id"])
+	appIds, err = db.GetAppsIDsForCollection(ctx.db, mux.Vars(r)["id"])
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
-	if !rows.Next() {
-		return http.StatusInternalServerError, errors.New("Specified collection does not exist")
-	}
-	var appIds_b []byte
-	var appIds []string
-	err = rows.Scan(&appIds_b)
-	if err != nil {
-		return http.StatusInternalServerError, err
-	}
-	json.Unmarshal(appIds_b, &appIds)
 
 	apps := make([]RebbleApplication, 0)
 	for _, id := range appIds {

--- a/collection.go
+++ b/collection.go
@@ -6,14 +6,13 @@ import (
 	"net/http"
 	"pebble-dev/rebblestore-api/db"
 	"strconv"
-	"time"
 
 	"github.com/gorilla/mux"
 )
 
-func insert(apps *([]RebbleApplication), location int, app RebbleApplication) *([]RebbleApplication) {
+func insert(apps *([]db.RebbleApplication), location int, app db.RebbleApplication) *([]db.RebbleApplication) {
 	beggining := (*apps)[:location]
-	end := make([]RebbleApplication, len(*apps)-len(beggining))
+	end := make([]db.RebbleApplication, len(*apps)-len(beggining))
 	copy(end, (*apps)[location:])
 	beggining = append(beggining, app)
 	beggining = append(beggining, end...)
@@ -21,8 +20,8 @@ func insert(apps *([]RebbleApplication), location int, app RebbleApplication) *(
 	return &beggining
 }
 
-func remove(apps *([]RebbleApplication), location int) *([]RebbleApplication) {
-	new := make([]RebbleApplication, location)
+func remove(apps *([]db.RebbleApplication), location int) *([]db.RebbleApplication) {
+	new := make([]db.RebbleApplication, location)
 	copy(new, (*apps)[:location])
 	new = append(new, (*apps)[location+1:]...)
 
@@ -39,8 +38,8 @@ func in_array(s string, array []string) bool {
 	return false
 }
 
-func bestApps(apps *([]RebbleApplication), sortByPopular bool, nApps int, platform string) *([]RebbleApplication) {
-	newApps := make([]RebbleApplication, 0)
+func bestApps(apps *([]db.RebbleApplication), sortByPopular bool, nApps int, platform string) *([]db.RebbleApplication) {
+	newApps := make([]db.RebbleApplication, 0)
 
 	for _, app := range *apps {
 		if platform == "all" || in_array(platform, app.SupportedPlatforms) {
@@ -71,26 +70,26 @@ func bestApps(apps *([]RebbleApplication), sortByPopular bool, nApps int, platfo
 	return &newApps
 }
 
-func sortApps(apps *([]RebbleApplication), sortByPopular bool) *([]RebbleApplication) {
-	newApps := make([]RebbleApplication, 0)
+func sortApps(apps *([]db.RebbleApplication), sortByPopular bool) *([]db.RebbleApplication) {
+	newApps := make([]db.RebbleApplication, 0)
 
 	for _, app := range *apps {
 		if len(newApps) == 0 {
-			newApps = []RebbleApplication{app}
+			newApps = []db.RebbleApplication{app}
 
 			continue
 		} else if len(newApps) == 1 {
 			if sortByPopular {
 				if newApps[0].ThumbsUp > app.ThumbsUp {
-					newApps = []RebbleApplication{newApps[0], app}
+					newApps = []db.RebbleApplication{newApps[0], app}
 				} else {
-					newApps = []RebbleApplication{app, newApps[0]}
+					newApps = []db.RebbleApplication{app, newApps[0]}
 				}
 			} else {
 				if newApps[0].Published.UnixNano() > app.Published.UnixNano() {
-					newApps = []RebbleApplication{app, newApps[0]}
+					newApps = []db.RebbleApplication{app, newApps[0]}
 				} else {
-					newApps = []RebbleApplication{newApps[0], app}
+					newApps = []db.RebbleApplication{newApps[0], app}
 				}
 			}
 
@@ -129,8 +128,6 @@ func sortApps(apps *([]RebbleApplication), sortByPopular bool) *([]RebbleApplica
 
 // CollectionHandler serves a list of cards from a collection
 func CollectionHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) (int, error) {
-	dbHandler := ctx.db
-
 	urlquery := r.URL.Query()
 
 	if _, ok := mux.Vars(r)["id"]; !ok {
@@ -172,27 +169,9 @@ func CollectionHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	appIds, err = db.GetAppsIDsForCollection(ctx.db, mux.Vars(r)["id"])
+	apps, err := db.GetAppsForCollection(ctx.db, mux.Vars(r)["id"])
 	if err != nil {
 		return http.StatusInternalServerError, err
-	}
-
-	apps := make([]RebbleApplication, 0)
-	for _, id := range appIds {
-		rows, err = dbHandler.Query("SELECT id, name, type, thumbs_up, icon_url, published_date, supported_platforms FROM apps WHERE id=?", id)
-		if err != nil {
-			return http.StatusInternalServerError, err
-		}
-
-		for rows.Next() {
-			app := RebbleApplication{}
-			var t int64
-			var supported_platforms_b []byte
-			err = rows.Scan(&app.Id, &app.Name, &app.Type, &app.ThumbsUp, &app.Assets.Icon, &t, &supported_platforms_b)
-			app.Published.Time = time.Unix(0, t)
-			err = json.Unmarshal(supported_platforms_b, &app.SupportedPlatforms)
-			apps = append(apps, app)
-		}
 	}
 
 	apps = *(bestApps(&apps, sortByPopular, page*12, platform))

--- a/db/models.go
+++ b/db/models.go
@@ -1,4 +1,4 @@
-package main
+package db
 
 // RebbleCard contains succint information about an app, to display on a result page for example
 type RebbleCard struct {

--- a/db/models.go
+++ b/db/models.go
@@ -13,3 +13,63 @@ type RebbleCard struct {
 type RebbleCards struct {
 	Cards []RebbleCard `json:"cards"`
 }
+
+// RebbleApplication contains Pebble App information from the DB
+type RebbleApplication struct {
+	Id                 string        `json:"id"`
+	Name               string        `json:"title"`
+	Author             RebbleAuthor  `json:"author"`
+	Description        string        `json:"description"`
+	ThumbsUp           int           `json:"thumbs_up"`
+	Type               string        `json:"type"`
+	SupportedPlatforms []string      `json:"supported_platforms"`
+	Published          JSONTime      `json:"published_date"`
+	AppInfo            RebbleAppInfo `json:"appInfo"`
+	Assets             RebbleAssets  `json:"assets"`
+	DoomsdayBackup     bool          `json:"doomsday_backup"`
+}
+
+// RebbleAppInfo contains information about the app (pbw url, versioning, links, etc.)
+type RebbleAppInfo struct {
+	PbwUrl      string             `json:"pbwUrl"`
+	RebbleReady bool               `json:"rebbleReady"`
+	Tags        []RebbleCollection `json:"tags"`
+	Updated     JSONTime           `json:"updated"`
+	Version     string             `json:"version"`
+	SupportUrl  string             `json:"supportUrl"`
+	AuthorUrl   string             `json:"authorUrl"`
+	SourceUrl   string             `json:"sourceUrl"`
+}
+
+// RebbleAuthor describes the autor of a Rebble app (ID and name)
+type RebbleAuthor struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// RebbleCollection describes the collection (category) of a Rebble application
+type RebbleCollection struct {
+	Id    string `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+// RebbleAssets describes the list of assets of a Rebble app (banner, icon, screenshots)
+type RebbleAssets struct {
+	Banner      string                         `json:"appBanner"`
+	Icon        string                         `json:"appIcon"`
+	Screenshots *([]RebbleScreenshotsPlatform) `json:"screenshots"`
+}
+
+// RebbleScreenshotsPlatform contains a list of screenshots specific to some hardware (since each Pebble watch renders UI differently)
+type RebbleScreenshotsPlatform struct {
+	Platform    string   `json:"platform"`
+	Screenshots []string `json:"screenshots"`
+}
+
+// RebbleVersion contains information about a specific version of an app
+type RebbleVersion struct {
+	Number      string   `json:"number"`
+	ReleaseDate JSONTime `json:"release_date"`
+	Description string   `json:"description"`
+}

--- a/db/queries.go
+++ b/db/queries.go
@@ -1,0 +1,24 @@
+package db
+
+import (
+	"database/sql"
+)
+
+// Search returns search results for applications
+func Search(handler *sql.DB, query string) (RebbleCards, error) {
+	var cards RebbleCards
+	rows, err := handler.Query(
+		"SELECT id, name, type, thumbs_up, icon_url FROM apps WHERE name LIKE ? ESCAPE '!' ORDER BY thumbs_up DESC LIMIT 12",
+		query,
+	)
+	if err != nil {
+		return cards, err
+	}
+	cards.Cards = make([]RebbleCard, 0)
+	for rows.Next() {
+		card := RebbleCard{}
+		err = rows.Scan(&card.Id, &card.Title, &card.Type, &card.ThumbsUp, &card.ImageUrl)
+		cards.Cards = append(cards.Cards, card)
+	}
+	return cards, nil
+}

--- a/db/queries.go
+++ b/db/queries.go
@@ -7,8 +7,13 @@ import (
 	"time"
 )
 
+// Handler contains reference to the database client
+type Handler struct {
+	*sql.DB
+}
+
 // Search returns search results for applications
-func Search(handler *sql.DB, query string) (RebbleCards, error) {
+func (handler Handler) Search(query string) (RebbleCards, error) {
 	var cards RebbleCards
 	rows, err := handler.Query(
 		"SELECT id, name, type, thumbs_up, icon_url FROM apps WHERE name LIKE ? ESCAPE '!' ORDER BY thumbs_up DESC LIMIT 12",
@@ -27,7 +32,7 @@ func Search(handler *sql.DB, query string) (RebbleCards, error) {
 }
 
 // GetAppsForCollection returns list of apps for single collection
-func GetAppsForCollection(handler *sql.DB, collectionID string) ([]RebbleApplication, error) {
+func (handler Handler) GetAppsForCollection(collectionID string) ([]RebbleApplication, error) {
 	rows, err := handler.Query("SELECT apps FROM collections WHERE id=?", collectionID)
 	if err != nil {
 		return nil, err
@@ -64,7 +69,7 @@ func GetAppsForCollection(handler *sql.DB, collectionID string) ([]RebbleApplica
 }
 
 // GetApps returns all available apps
-func GetApps(handler *sql.DB) ([]RebbleApplication, error) {
+func (handler Handler) GetApps() ([]RebbleApplication, error) {
 	rows, err := handler.Query(`
 		SELECT apps.name, authors.name
 		FROM apps

--- a/db/queries.go
+++ b/db/queries.go
@@ -62,3 +62,28 @@ func GetAppsForCollection(handler *sql.DB, collectionID string) ([]RebbleApplica
 	}
 	return apps, nil
 }
+
+// GetApps returns all available apps
+func GetApps(handler *sql.DB) ([]RebbleApplication, error) {
+	rows, err := handler.Query(`
+		SELECT apps.name, authors.name
+		FROM apps
+		JOIN authors ON apps.author_id = authors.id
+		ORDER BY published_date ASC LIMIT 20
+	`)
+	if err != nil {
+		return nil, err
+	}
+	apps := make([]RebbleApplication, 0)
+	for rows.Next() {
+		app := RebbleApplication{}
+		err = rows.Scan(&app.Name, &app.Author.Name)
+		apps = append(apps, app)
+	}
+	return apps, nil
+}
+
+// GetApp
+// func GetApp(handler *sql.DB, id string) (RebbleApplication, error) {
+// 	return nil, nil
+// }

--- a/db/queries.go
+++ b/db/queries.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"database/sql"
+	"encoding/json"
+	"errors"
 )
 
 // Search returns search results for applications
@@ -21,4 +23,23 @@ func Search(handler *sql.DB, query string) (RebbleCards, error) {
 		cards.Cards = append(cards.Cards, card)
 	}
 	return cards, nil
+}
+
+// GetAppsIDsForCollection returns list of apps for single collection
+func GetAppsIDsForCollection(handler *sql.DB, collectionID string) ([]string, error) {
+	rows, err := handler.Query("SELECT apps FROM collections WHERE id=?", collectionID)
+	if err != nil {
+		return nil, err
+	}
+	if !rows.Next() {
+		return nil, errors.New("Specified collection does not exist")
+	}
+	var appIdsB []byte
+	var appIds []string
+	err = rows.Scan(&appIdsB)
+	if err != nil {
+		return nil, err
+	}
+	json.Unmarshal(appIdsB, &appIds)
+	return appIds, nil
 }

--- a/db/types.go
+++ b/db/types.go
@@ -1,0 +1,30 @@
+package db
+
+import (
+	"time"
+)
+
+// JSONTime is a dummy time object that is meant to allow Go's JSON module to
+// properly de-serialize the JSON time format.
+type JSONTime struct {
+	time.Time
+}
+
+// UnmarshalJSON allows for the custom time format within the application JSON
+// to be decoded into Go's native time format.
+func (self *JSONTime) UnmarshalJSON(b []byte) (err error) {
+	s := string(b)
+
+	// Return an empty time.Time object if it didn't exist in the first place.
+	if s == "null" {
+		self.Time = time.Time{}
+		return
+	}
+
+	t, err := time.Parse("\"2006-01-02T15:04:05.999Z\"", s)
+	if err != nil {
+		t = time.Time{}
+	}
+	self.Time = t
+	return
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"pebble-dev/rebblestore-api/db"
 
 	"github.com/gorilla/handlers"
 	_ "github.com/mattn/go-sqlite3"
@@ -22,13 +23,15 @@ func main() {
 		return
 	}
 
-	db, err := sql.Open("sqlite3", "./RebbleAppStore.db")
+	database, err := sql.Open("sqlite3", "./RebbleAppStore.db")
 	if err != nil {
 		panic("Could not connect to database" + err.Error())
 	}
 
+	dbHandler := db.Handler{database}
+
 	// construct the context that will be injected in to handlers
-	context := &handlerContext{db}
+	context := &handlerContext{&dbHandler}
 
 	r := Handlers(context)
 	loggedRouter := handlers.LoggingHandler(os.Stdout, r)

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"database/sql"
 	"os"
+	"pebble-dev/rebblestore-api/db"
 	"testing"
 
 	"github.com/adams-sarah/test2doc/test"
@@ -16,12 +17,13 @@ var server *test.Server
 func TestMain(m *testing.M) {
 	var err error
 
-	db, err := sql.Open("sqlite3", "./foo_test.db")
+	database, err := sql.Open("sqlite3", "./RebbleAppStore.db")
 	if err != nil {
 		panic("Could not connect to database" + err.Error())
 	}
 
-	context := &handlerContext{db}
+	dbHandler := db.Handler{database}
+	context := &handlerContext{&dbHandler}
 
 	var r = Handlers(context)
 	r.KeepContext = true

--- a/routehandler.go
+++ b/routehandler.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-	"database/sql"
 	"log"
 	"net/http"
+	"pebble-dev/rebblestore-api/db"
 )
 
 // handlerContext is our struct for storing the data we want to inject in to each handler
 // we can also add things like authorization level, user information, templates, etc.
 type handlerContext struct {
-	db *sql.DB
+	db *db.Handler
 }
 
 // routeHandler is a struct that implements http.Handler, allowing us to inject a custom context

--- a/search.go
+++ b/search.go
@@ -23,7 +23,7 @@ func SearchHandler(ctx *handlerContext, w http.ResponseWriter, r *http.Request) 
 	query = strings.Replace(query, "[", "![", -1)
 	query = "%" + query + "%"
 	var cards db.RebbleCards
-	cards, err := db.Search(ctx.db, query)
+	cards, err := ctx.db.Search(query)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}


### PR DESCRIPTION
Keeping things separate - there should be no raw SQL queries in controllers/route handlers.

This changes `ctx.db` in context from `*sql.DB` to `*db.Handler`, which also has all query methods (in `db/queries.go`).

### Todo

- [x] move queries from `search.go`
- [x] move queries from `collections.go`
- ~~move queries from `admin.go`~~ will not be done here
- ~~move queries from `application.go`~~ will not be done here