### PR TITLE
Reworked sorting approach

### DIFF
--- a/rebbleHandlers/collection.go
+++ b/rebbleHandlers/collection.go
@@ -59,23 +59,6 @@ func nCompatibleApps(apps *([]db.RebbleApplication), platform string) int {
 
 type Comparator func(a *db.RebbleApplication, b *db.RebbleApplication) bool
 
-type sorter struct {
-	data       []db.RebbleApplication
-	comparator Comparator
-}
-
-func (s sorter) Len() int {
-	return len(s.data)
-}
-
-func (s sorter) Swap(i, j int) {
-	s.data[i], s.data[j] = s.data[j], s.data[i]
-}
-
-func (s sorter) Less(i, j int) bool {
-	return s.comparator(&s.data[i], &s.data[j])
-}
-
 // PopularFirst is a comparator that sorts applications by ThumbsUp ascending
 func PopularFirst(a *db.RebbleApplication, b *db.RebbleApplication) bool {
 	return a.ThumbsUp > b.ThumbsUp
@@ -111,7 +94,9 @@ func bestApps(apps *([]db.RebbleApplication), sortBy Comparator, nApps int, plat
 func sortApps(apps *[]db.RebbleApplication, comparator Comparator) *([]db.RebbleApplication) {
 	sortedApps := make([]db.RebbleApplication, len(*apps))
 	copy(sortedApps, *apps)
-	sort.Sort(sorter{sortedApps, comparator})
+	sort.Slice(sortedApps, func(i, j int) bool {
+		return comparator(&sortedApps[i], &sortedApps[j])
+	})
 	return &sortedApps
 }
 

--- a/rebbleHandlers/collection.go
+++ b/rebbleHandlers/collection.go
@@ -70,13 +70,13 @@ func PopularLast(a *db.RebbleApplication, b *db.RebbleApplication) bool {
 }
 
 // NewelyPublishedFirst is a comparator that sorts applications by Published date ascending
-func NewelyPublishedFirst(a *db.RebbleApplication, b *db.RebbleApplication) bool {
+func NewlyPublishedFirst(a *db.RebbleApplication, b *db.RebbleApplication) bool {
 	return a.Published.UnixNano() > b.Published.UnixNano()
 }
 
 // OldestPublishedFirst is a comparator that sorts applications by Published date descending
 func OldestPublishedFirst(a *db.RebbleApplication, b *db.RebbleApplication) bool {
-	return !NewelyPublishedFirst(a, b)
+	return !NewlyPublishedFirst(a, b)
 }
 
 func bestApps(apps *([]db.RebbleApplication), sortBy Comparator, nApps int, platform string) *([]db.RebbleApplication) {
@@ -108,14 +108,14 @@ func CollectionHandler(ctx *HandlerContext, w http.ResponseWriter, r *http.Reque
 		return http.StatusBadRequest, errors.New("Missing 'id' parameter")
 	}
 
-	sortBy := NewelyPublishedFirst
+	sortBy := NewlyPublishedFirst
 	if o, ok := urlquery["order"]; ok {
 		if len(o) > 1 {
 			return http.StatusBadRequest, errors.New("Multiple 'order' parameters are not allowed")
 		} else if o[0] == "popular" {
 			sortBy = PopularFirst
 		} else if o[0] == "new" {
-			sortBy = NewelyPublishedFirst
+			sortBy = NewlyPublishedFirst
 		} else {
 			return http.StatusBadRequest, errors.New("Invalid 'order' parameter")
 		}

--- a/rebbleHandlers/collection.go
+++ b/rebbleHandlers/collection.go
@@ -60,20 +60,20 @@ func nCompatibleApps(apps *([]db.RebbleApplication), platform string) int {
 type Comparator func(a *db.RebbleApplication, b *db.RebbleApplication) bool
 
 type sorter struct {
-	data       *[]db.RebbleApplication
+	data       []db.RebbleApplication
 	comparator Comparator
 }
 
 func (s sorter) Len() int {
-	return len(*s.data)
+	return len(s.data)
 }
 
 func (s sorter) Swap(i, j int) {
-	(*s.data)[i], (*s.data)[j] = (*s.data)[j], (*s.data)[i]
+	s.data[i], s.data[j] = s.data[j], s.data[i]
 }
 
 func (s sorter) Less(i, j int) bool {
-	return s.comparator(&(*s.data)[i], &(*s.data)[j])
+	return s.comparator(&s.data[i], &s.data[j])
 }
 
 // PopularFirst is a comparator that sorts applications by ThumbsUp ascending
@@ -111,7 +111,7 @@ func bestApps(apps *([]db.RebbleApplication), sortBy Comparator, nApps int, plat
 func sortApps(apps *[]db.RebbleApplication, comparator Comparator) *([]db.RebbleApplication) {
 	sortedApps := make([]db.RebbleApplication, len(*apps))
 	copy(sortedApps, *apps)
-	sort.Sort(sorter{&sortedApps, comparator})
+	sort.Sort(sorter{sortedApps, comparator})
 	return &sortedApps
 }
 

--- a/rebbleHandlers/collection.go
+++ b/rebbleHandlers/collection.go
@@ -96,10 +96,6 @@ func OldestPublishedFirst(a *db.RebbleApplication, b *db.RebbleApplication) bool
 	return !NewelyPublishedFirst(a, b)
 }
 
-func makeSort(apps *[]db.RebbleApplication, comparator Comparator) sorter {
-	return sorter{apps, comparator}
-}
-
 func bestApps(apps *([]db.RebbleApplication), sortBy Comparator, nApps int, platform string) *([]db.RebbleApplication) {
 	sortedApps := sortApps(apps, sortBy)
 
@@ -107,15 +103,15 @@ func bestApps(apps *([]db.RebbleApplication), sortBy Comparator, nApps int, plat
 		return sortedApps
 	}
 
-	nAppsSlice := make([]db.RebbleApplication, nApps)
-	copy(nAppsSlice, *sortedApps)
-	return &nAppsSlice
+	nSortedApps := make([]db.RebbleApplication, nApps)
+	copy(nSortedApps, *sortedApps)
+	return &nSortedApps
 }
 
 func sortApps(apps *[]db.RebbleApplication, comparator Comparator) *([]db.RebbleApplication) {
 	sortedApps := make([]db.RebbleApplication, len(*apps))
 	copy(sortedApps, *apps)
-	sort.Sort(makeSort(&sortedApps, comparator))
+	sort.Sort(sorter{&sortedApps, comparator})
 	return &sortedApps
 }
 

--- a/rebbleHandlers/collection.go
+++ b/rebbleHandlers/collection.go
@@ -18,24 +18,6 @@ type RebbleCollection struct {
 	Cards []db.RebbleCard `json:"cards"`
 }
 
-func insert(apps *([]db.RebbleApplication), location int, app db.RebbleApplication) *([]db.RebbleApplication) {
-	beggining := (*apps)[:location]
-	end := make([]db.RebbleApplication, len(*apps)-len(beggining))
-	copy(end, (*apps)[location:])
-	beggining = append(beggining, app)
-	beggining = append(beggining, end...)
-
-	return &beggining
-}
-
-func remove(apps *([]db.RebbleApplication), location int) *([]db.RebbleApplication) {
-	new := make([]db.RebbleApplication, location)
-	copy(new, (*apps)[:location])
-	new = append(new, (*apps)[location+1:]...)
-
-	return &new
-}
-
 func in_array(s string, array []string) bool {
 	for _, item := range array {
 		if item == s {


### PR DESCRIPTION
This pull request replaces custom sorting approach by standard library sort implementation. 
Now apps could be sorted by using Comparator predicate.

NOTE: it use `sort.Slice` that is part of Go 1.8