### PR TITLE
Added AppsHandler endpoint

### DIFF
--- a/db/queries.go
+++ b/db/queries.go
@@ -127,8 +127,10 @@ func (handler Handler) GetAllApps(sortby string, ascending bool, offset int, lim
 	switch sortby {
 	case "popular":
 		orderCol = "apps.thumbs_up"
-	default:
+	case "recent":
 		orderCol = "apps.published_date"
+	default:
+		return nil, errors.New("Invalid sortby parameter")
 	}
 
 	// this code looks weird, but ORDER BY does not currently work with prepared statements,

--- a/db/queries.go
+++ b/db/queries.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"log"
 	"strings"
 	"time"
 )
@@ -131,8 +130,6 @@ func (handler Handler) GetAllApps(sortby string, ascending bool, offset int, lim
 	default:
 		orderCol = "apps.published_date"
 	}
-
-	log.Printf("Sort by: %v\nLimit: %v\nOffset: %v\n", orderCol+" "+order, limit, offset)
 
 	// this code looks weird, but ORDER BY does not currently work with prepared statements,
 	// that is why it is written this way. it should be completely safe as it doesn't take user input

--- a/db/queries.go
+++ b/db/queries.go
@@ -132,16 +132,18 @@ func (handler Handler) GetAllApps(sortby string, ascending bool, offset int, lim
 		orderCol = "apps.published_date"
 	}
 
-	log.Printf("Sort by: %v\nOrder: %v\nLimit: %v\nOffset: %v\n", orderCol, order, limit, offset)
+	log.Printf("Sort by: %v\nLimit: %v\nOffset: %v\n", orderCol+" "+order, limit, offset)
 
+	// this code looks weird, but ORDER BY does not currently work with prepared statements,
+	// that is why it is written this way. it should be completely safe as it doesn't take user input
 	rows, err := handler.Query(`
 		SELECT apps.name, authors.name, apps.icon_url, apps.id, apps.thumbs_up, apps.published_date
 		FROM apps
 		JOIN authors ON apps.author_id = authors.id
-		ORDER BY ?
+		ORDER BY `+orderCol+" "+order+`
 		LIMIT ?
 		OFFSET ?
-	`, orderCol+" "+order, limit, offset)
+	`, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -5,15 +5,13 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"pebble-dev/rebblestore-api/db"
 
 	"github.com/gorilla/handlers"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/pborman/getopt"
-	//rsapi "github.com/pebble-dev/rebblestore-api"
-
-	"pebble-dev/rebblestore-api/common"
-	"pebble-dev/rebblestore-api/rebbleHandlers"
+	"github.com/pebble-dev/rebblestore-api/common"
+	"github.com/pebble-dev/rebblestore-api/db"
+	"github.com/pebble-dev/rebblestore-api/rebbleHandlers"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"os"
 
+	"pebble-dev/rebblestore-api/common"
+	"pebble-dev/rebblestore-api/db"
+	"pebble-dev/rebblestore-api/rebbleHandlers"
+
 	"github.com/gorilla/handlers"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/pborman/getopt"
-	"github.com/pebble-dev/rebblestore-api/common"
-	"github.com/pebble-dev/rebblestore-api/db"
-	"github.com/pebble-dev/rebblestore-api/rebbleHandlers"
 )
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -5,12 +5,13 @@ import (
 	"os"
 	"testing"
 
+	"pebble-dev/rebblestore-api/db"
+	"pebble-dev/rebblestore-api/rebbleHandlers"
+
 	"github.com/adams-sarah/test2doc/test"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/pebble-dev/rebblestore-api/db"
-	"github.com/pebble-dev/rebblestore-api/rebbleHandlers"
 )
 
 var server *test.Server

--- a/main_test.go
+++ b/main_test.go
@@ -3,14 +3,14 @@ package main
 import (
 	"database/sql"
 	"os"
-	"pebble-dev/rebblestore-api/db"
-	"pebble-dev/rebblestore-api/rebbleHandlers"
 	"testing"
 
 	"github.com/adams-sarah/test2doc/test"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/pebble-dev/rebblestore-api/db"
+	"github.com/pebble-dev/rebblestore-api/rebbleHandlers"
 )
 
 var server *test.Server

--- a/rebbleHandlers/admin.go
+++ b/rebbleHandlers/admin.go
@@ -8,12 +8,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"pebble-dev/rebblestore-api/db"
 	"strings"
 
-	"github.com/nu7hatch/gouuid"
-
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/nu7hatch/gouuid"
+	"github.com/pebble-dev/rebblestore-api/db"
 )
 
 // walkFiles is intended to quickly crawl the pebble application folder

--- a/rebbleHandlers/admin.go
+++ b/rebbleHandlers/admin.go
@@ -10,9 +10,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"pebble-dev/rebblestore-api/db"
+
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/nu7hatch/gouuid"
-	"github.com/pebble-dev/rebblestore-api/db"
 )
 
 // walkFiles is intended to quickly crawl the pebble application folder

--- a/rebbleHandlers/application.go
+++ b/rebbleHandlers/application.go
@@ -9,8 +9,9 @@ import (
 	"os"
 	"strconv"
 
+	"pebble-dev/rebblestore-api/db"
+
 	"github.com/gorilla/mux"
-	"github.com/pebble-dev/rebblestore-api/db"
 )
 
 // PebbleAppList contains a list of PebbleApplication. It matches the format of Pebble API answers.

--- a/rebbleHandlers/application.go
+++ b/rebbleHandlers/application.go
@@ -268,7 +268,7 @@ func AppsHandler(ctx *HandlerContext, w http.ResponseWriter, r *http.Request) (i
 
 	sortby := mux.Vars(r)["sortby"]
 
-	apps, err := ctx.Database.GetAllApps(sortby, ascending, page*limit, limit)
+	apps, err := ctx.Database.GetAllApps(sortby, ascending, (page-1)*limit, limit)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}

--- a/rebbleHandlers/application.go
+++ b/rebbleHandlers/application.go
@@ -136,6 +136,7 @@ func parseApp(path string, authors *map[string]int, lastAuthorId *int, collectio
 
 	err = json.Unmarshal(f, &data)
 	if err != nil {
+		log.Print("Error parsing app JSON: " + path)
 		return nil, nil, err
 	}
 	if len(data.Apps) != 1 {

--- a/rebbleHandlers/application.go
+++ b/rebbleHandlers/application.go
@@ -253,12 +253,16 @@ func RecurseFolder(w http.ResponseWriter, path string, f os.FileInfo, lvl int) {
 func AppsHandler(ctx *HandlerContext, w http.ResponseWriter, r *http.Request) (int, error) {
 	page, err := strconv.Atoi(mux.Vars(r)["page"])
 	if err != nil {
-		return http.StatusInternalServerError, err
+		return http.StatusBadRequest, err
 	}
 
 	limit, err := strconv.Atoi(mux.Vars(r)["limit"])
 	if err != nil {
-		return http.StatusInternalServerError, err
+		return http.StatusBadRequest, err
+	}
+
+	if limit > 50 {
+		limit = 50
 	}
 
 	var ascending bool

--- a/rebbleHandlers/boot_test.go
+++ b/rebbleHandlers/boot_test.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"pebble-dev/rebblestore-api/common"
+
 	"github.com/adams-sarah/test2doc/test"
-	"github.com/pebble-dev/rebblestore-api/common"
 )
 
 var server *test.Server

--- a/rebbleHandlers/boot_test.go
+++ b/rebbleHandlers/boot_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"pebble-dev/rebblestore-api/common"
 	"strings"
 	"testing"
 
 	"github.com/adams-sarah/test2doc/test"
+	"github.com/pebble-dev/rebblestore-api/common"
 )
 
 var server *test.Server

--- a/rebbleHandlers/collection.go
+++ b/rebbleHandlers/collection.go
@@ -6,8 +6,9 @@ import (
 	"net/http"
 	"strconv"
 
+	"pebble-dev/rebblestore-api/db"
+
 	"github.com/gorilla/mux"
-	"github.com/pebble-dev/rebblestore-api/db"
 )
 
 type RebbleCollection struct {

--- a/rebbleHandlers/collection.go
+++ b/rebbleHandlers/collection.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"pebble-dev/rebblestore-api/db"
 	"strconv"
 
 	"github.com/gorilla/mux"
+	"github.com/pebble-dev/rebblestore-api/db"
 )
 
 type RebbleCollection struct {

--- a/rebbleHandlers/routehandler.go
+++ b/rebbleHandlers/routehandler.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/pebble-dev/rebblestore-api/db"
+	"pebble-dev/rebblestore-api/db"
 )
 
 // HandlerContext is our struct for storing the data we want to inject in to each handler

--- a/rebbleHandlers/routehandler.go
+++ b/rebbleHandlers/routehandler.go
@@ -3,7 +3,8 @@ package rebbleHandlers
 import (
 	"log"
 	"net/http"
-	"pebble-dev/rebblestore-api/db"
+
+	"github.com/pebble-dev/rebblestore-api/db"
 )
 
 // HandlerContext is our struct for storing the data we want to inject in to each handler

--- a/rebbleHandlers/routes.go
+++ b/rebbleHandlers/routes.go
@@ -19,7 +19,7 @@ func DummyHandler(w http.ResponseWriter, r *http.Request) {
 func Handlers(context *HandlerContext) *mux.Router {
 	r := mux.NewRouter()
 	r.Handle("/", routeHandler{context, HomeHandler}).Methods("GET")
-	r.Handle("/dev/apps/get_apps/page/{page}", routeHandler{context, AppsHandler}).Methods("GET").Queries("limit", "order", "sortby")
+	r.Handle("/dev/apps/get_apps/page/{page:[0-9]+}", routeHandler{context, AppsHandler}).Methods("GET").Queries("limit", "{limit:[0-5]?[0-9]{1}}", "order", "{order:asc|desc}", "sortby", "{sortby:popular|recent}")
 	r.Handle("/dev/apps/get_app/id/{id}", routeHandler{context, AppHandler}).Methods("GET")
 	r.Handle("/dev/apps/get_tags/id/{id}", routeHandler{context, TagsHandler}).Methods("GET")
 	r.Handle("/dev/apps/get_versions/id/{id}", routeHandler{context, VersionsHandler}).Methods("GET")

--- a/rebbleHandlers/routes.go
+++ b/rebbleHandlers/routes.go
@@ -19,7 +19,7 @@ func DummyHandler(w http.ResponseWriter, r *http.Request) {
 func Handlers(context *HandlerContext) *mux.Router {
 	r := mux.NewRouter()
 	r.Handle("/", routeHandler{context, HomeHandler}).Methods("GET")
-	r.Handle("/dev/apps/get_apps/page/{page:[0-9]+}", routeHandler{context, AppsHandler}).Methods("GET").Queries("limit", "{limit:[0-5]?[0-9]{1}}", "order", "{order:asc|desc}", "sortby", "{sortby:popular|recent}")
+	r.Handle("/dev/apps/get_apps/page/{page:[0-9]+}", routeHandler{context, AppsHandler}).Methods("GET")
 	r.Handle("/dev/apps/get_app/id/{id}", routeHandler{context, AppHandler}).Methods("GET")
 	r.Handle("/dev/apps/get_tags/id/{id}", routeHandler{context, TagsHandler}).Methods("GET")
 	r.Handle("/dev/apps/get_versions/id/{id}", routeHandler{context, VersionsHandler}).Methods("GET")

--- a/rebbleHandlers/routes.go
+++ b/rebbleHandlers/routes.go
@@ -19,7 +19,7 @@ func DummyHandler(w http.ResponseWriter, r *http.Request) {
 func Handlers(context *HandlerContext) *mux.Router {
 	r := mux.NewRouter()
 	r.Handle("/", routeHandler{context, HomeHandler}).Methods("GET")
-	r.Handle("/dev/apps", routeHandler{context, AppsHandler}).Methods("GET")
+	r.Handle("/dev/apps/get_apps/page/{page}", routeHandler{context, AppsHandler}).Methods("GET").Queries("limit", "order", "sortby")
 	r.Handle("/dev/apps/get_app/id/{id}", routeHandler{context, AppHandler}).Methods("GET")
 	r.Handle("/dev/apps/get_tags/id/{id}", routeHandler{context, TagsHandler}).Methods("GET")
 	r.Handle("/dev/apps/get_versions/id/{id}", routeHandler{context, VersionsHandler}).Methods("GET")

--- a/rebbleHandlers/version.go
+++ b/rebbleHandlers/version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pebble-dev/rebblestore-api/common"
+	"pebble-dev/rebblestore-api/common"
 )
 
 // AdminVersionHandler returns the latest build information from the host

--- a/rebbleHandlers/version.go
+++ b/rebbleHandlers/version.go
@@ -3,7 +3,8 @@ package rebbleHandlers
 import (
 	"fmt"
 	"net/http"
-	"pebble-dev/rebblestore-api/common"
+
+	"github.com/pebble-dev/rebblestore-api/common"
 )
 
 // AdminVersionHandler returns the latest build information from the host


### PR DESCRIPTION
In this pull request I've added the AppsHandler endpoint, which serves a list of apps.

It has 3 parameters: page, limit, sortby, and order.

Page and limit are used together to determine the pagination. For example, if you set `page` to 3 and `limit` to 20, it will give you 20 results, and skip the first 40 (assuming you've gone through 2 previous pages with a limit of 20).

Sortby and order allow you to sort by thumbs_up or published_date, ascending or descending.

Also, I changed the imports for local packages to have the "github.com/" prefix. I'm also open to changing this, but I believe this way is more idiomatic. Again, open to other opinions.